### PR TITLE
Add card component

### DIFF
--- a/packages/admin-react/src/index.tsx
+++ b/packages/admin-react/src/index.tsx
@@ -1,4 +1,5 @@
 import Button from './ui/Button';
+import Card from './ui/Card';
 import Checkbox from './ui/Checkbox';
 import Form from './ui/Form';
 import FormCheckboxes from './ui/FormCheckboxes';
@@ -15,6 +16,7 @@ import BasePage from './pages/BasePage';
 const plugin = {
     install(addComponent) {
         addComponent('ui-checkbox', Checkbox);
+        addComponent('ui-card', Card);
         addComponent('ui-form', Form);
         addComponent('ui-form-checkboxes', FormCheckboxes);
         addComponent('ui-form-input', FormInput);
@@ -33,5 +35,6 @@ const pages = { BasePage };
 export { 
     plugin, 
     pages, 
-    Button
+    Button,
+    Card
 };

--- a/packages/admin-react/src/ui/Card.tsx
+++ b/packages/admin-react/src/ui/Card.tsx
@@ -1,0 +1,32 @@
+import classNames from 'classnames';
+import getVariant from './props/variant';
+import getSize from './props/size';
+
+type CardProps = {
+    as?: string,
+    [k: string]: any
+}
+
+const Card = function({ 
+    as = 'div', 
+    ...props
+}: CardProps, context) {
+    const Tag = as as keyof JSX.IntrinsicElements;
+    const variant = getVariant(props, { DEFAULT: 'white' });
+    const size = getSize(props, { only: ['sm', 'md'] });
+
+    return (
+        <Tag className={classNames({
+            'rounded-sm p-6': true,
+            'bg-white shadow': variant == 'white',
+            'bg-gray-300': variant == 'gray',
+            'p-12': size == 'md',
+            'p-8': size == 'sm',
+            [props.className]: true
+        })}>
+            {props.children}
+        </Tag>
+    );
+}
+
+export default Card;

--- a/packages/admin-react/src/ui/props/size.ts
+++ b/packages/admin-react/src/ui/props/size.ts
@@ -1,16 +1,25 @@
 import { useEffect, useState } from 'react';
 
-export default function getSize(props) {
-    let [size, setSize] = useState('md');
+type SizeOptions = {
+    DEFAULT?: string,
+    only?: string[],
+}
+
+export default function getSize(props, options?:SizeOptions) {
+    let { 
+        DEFAULT = 'md', 
+        only = ['sm', 'md', 'lg'], 
+    } = options;
+    let [size, setSize] = useState(DEFAULT);
 
     useEffect(() => {
         if (props.variant) {
             setSize(props.size);
-        } else if (props.sm) {
+        } else if (props.sm && only.includes('sm')) {
             setSize('sm');
-        } else if (props.md) {
+        } else if (props.md && only.includes('md')) {
             setSize('md');
-        } else if (props.lg) {
+        } else if (props.lg && only.includes('lg')) {
             setSize('lg');
         } else {
             setSize('md');

--- a/packages/admin-react/src/ui/props/variant.ts
+++ b/packages/admin-react/src/ui/props/variant.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 
-export default function getVariant(props) {
+type VariantOptions = {
+    DEFAULT?: string
+}
+
+export default function getVariant(props, options?: VariantOptions) {
+    let { DEFAULT = 'blue' } = options;
     let [variant, setVariant] = useState('blue');
 
     useEffect(() => {
@@ -17,7 +22,7 @@ export default function getVariant(props) {
         } else if (props.red) {
             setVariant('red');
         } else {
-            setVariant('blue');
+            setVariant(DEFAULT);
         }
     }, [props]);
 

--- a/packages/admin-vue3/src/index.js
+++ b/packages/admin-vue3/src/index.js
@@ -1,4 +1,5 @@
-import Button from './ui/Button.vue';
+// import Button from './ui/Button.vue';
+import Badge from './ui/Badge.vue';
 import Checkbox from './ui/Checkbox.vue';
 import Form from './ui/Form.vue';
 import FormCheckboxes from './ui/FormCheckboxes.vue';
@@ -13,7 +14,8 @@ import BasePage from './pages/BasePage';
 
 const plugin = {
     install(app) {
-        app.component('UiButton', Button);
+        // app.component('UiButton', Button);
+        app.component('UiBadge', Badge);
         app.component('UiCheckbox', Checkbox);
         app.component('UiForm', Form);
         app.component('UiFormCheckboxes', FormCheckboxes);

--- a/packages/admin-vue3/src/index.js
+++ b/packages/admin-vue3/src/index.js
@@ -1,4 +1,5 @@
 // import Button from './ui/Button.vue';
+import Card from './ui/Card.vue';
 import Badge from './ui/Badge.vue';
 import Checkbox from './ui/Checkbox.vue';
 import Form from './ui/Form.vue';
@@ -15,6 +16,7 @@ import BasePage from './pages/BasePage';
 const plugin = {
     install(app) {
         // app.component('UiButton', Button);
+        app.component('UiCard', Card);
         app.component('UiBadge', Badge);
         app.component('UiCheckbox', Checkbox);
         app.component('UiForm', Form);

--- a/packages/admin-vue3/src/ui/Badge.vue
+++ b/packages/admin-vue3/src/ui/Badge.vue
@@ -1,0 +1,42 @@
+<template>
+    <component
+        :is="tag"
+        class="inline-flex justify-center items-center px-2 rounded-xs text-sm"
+        :class="{
+            'bg-blue text-white ':
+                variant == 'blue' && !outline && !text && !disabled,
+
+            'bg-gray-700  text-white':
+                variant == 'gray' && !outline && !text && !disabled,
+
+            'bg-green  text-green-700':
+                variant == 'green' && !outline && !text && !disabled,
+
+            'bg-red  text-red-700':
+                variant == 'red' && !outline && !text && !disabled,
+
+            'bg-yellow  text-yellow-700':
+                variant == 'yellow' && !outline && !text && !disabled,
+        }"
+    >
+        <slot />
+    </component>
+</template>
+
+<script>
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    props: {
+        variant: {
+            default: 'blue',
+            type: String,
+        },
+    },
+    setup(props, { attrs }) {
+        const tag = 'href' in attrs ? 'a' : 'div';
+
+        return { tag };
+    },
+});
+</script>

--- a/packages/admin-vue3/src/ui/Card.vue
+++ b/packages/admin-vue3/src/ui/Card.vue
@@ -1,30 +1,26 @@
 <template>
     <component
-        :is="tag"
-        class="w-full rounded-sm"
+        :is="as"
+        class="rounded-sm p-6"
         :class="{
-            'bg-white py-14 shadow': !info,
-            'bg-gray-300 pb-9 pt-7': info,
-
-            'px-14': !disableContainer && !info,
-            'px-8': !disableContainer && info,
+            'bg-white shadow': variant_ == 'white',
+            'bg-gray-300': variant_ == 'gray',
+            'p-12': size_ == 'md',
+            'p-8': size_ == 'sm',
         }"
     >
-        <slot name="header" />
-        <div class="mb-3 font-semibold text-md">{{ title }}</div>
-        <div class="text-xs">
-            <slot />
-        </div>
-        <slot name="footer" />
+        <slot />
     </component>
 </template>
 
-<script>
-import { defineComponent } from 'vue';
+<script lang="ts">
+import { defineComponent, computed } from 'vue';
+import { getVariant, variants } from './props/variant';
+import { getSize, sizes } from './props/size';
 
 export default defineComponent({
     props: {
-        tag: {
+        as: {
             type: String,
             default: 'div',
         },
@@ -40,6 +36,21 @@ export default defineComponent({
             type: String,
             default: '',
         },
+        variant: variants.variant,
+        white: {
+            type: Boolean,
+            default: false,
+        },
+        gray: variants.gray,
+        size: sizes.size,
+        sm: sizes.sm,
+        md: sizes.md,
+    },
+    setup(props, { attrs }) {
+        let variant_ = getVariant(props, { DEFAULT: 'white' });
+        let size_ = getSize(props, { only: ['sm', 'md'] });
+
+        return { variant_, size_ };
     },
 });
 </script>

--- a/packages/admin-vue3/src/ui/Card.vue
+++ b/packages/admin-vue3/src/ui/Card.vue
@@ -1,0 +1,47 @@
+<template>
+    <component
+        :is="tag"
+        class="w-full rounded-sm"
+        :class="{
+            'bg-white py-14 shadow': !info,
+            'bg-gray-300 pb-9 pt-7': info,
+
+            'px-14': !disableContainer && !info,
+            'px-8': !disableContainer && info,
+        }"
+    >
+        <slot name="header" />
+        <div class="mb-3 font-semibold text-md">{{ title }}</div>
+        <div class="text-xs">
+            <slot />
+        </div>
+        <slot name="footer" />
+    </component>
+</template>
+
+<script>
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    props: {
+        tag: {
+            type: String,
+            default: 'div',
+        },
+        info: {
+            type: Boolean,
+            default: false,
+        },
+        disableContainer: {
+            type: Boolean,
+            default: false,
+        },
+        title: {
+            type: String,
+            default: '',
+        },
+    },
+});
+</script>
+
+<style></style>

--- a/packages/admin-vue3/src/ui/Card.vue
+++ b/packages/admin-vue3/src/ui/Card.vue
@@ -24,18 +24,6 @@ export default defineComponent({
             type: String,
             default: 'div',
         },
-        info: {
-            type: Boolean,
-            default: false,
-        },
-        disableContainer: {
-            type: Boolean,
-            default: false,
-        },
-        title: {
-            type: String,
-            default: '',
-        },
         variant: variants.variant,
         white: {
             type: Boolean,

--- a/packages/admin-vue3/src/ui/props/size.js
+++ b/packages/admin-vue3/src/ui/props/size.js
@@ -1,18 +1,18 @@
 import { computed } from 'vue';
 
-export function getSize(props) {
+export function getSize(props, { only = ['sm', 'md', 'lg'] }) {
     return computed(() => {
         if (props.size) {
             return props.size;
         }
 
-        if (props.sm) {
+        if (props.sm && only.includes('sm')) {
             return 'sm';
         }
-        if (props.md) {
+        if (props.md && only.includes('md')) {
             return 'md';
         }
-        if (props.lg) {
+        if (props.lg && only.includes('lg')) {
             return 'lg';
         }
 

--- a/packages/admin-vue3/src/ui/props/size.js
+++ b/packages/admin-vue3/src/ui/props/size.js
@@ -1,6 +1,6 @@
 import { computed } from 'vue';
 
-export function getSize(props, { only = ['sm', 'md', 'lg'] }) {
+export function getSize(props, { DEFAULT = 'md', only = ['sm', 'md', 'lg'] }) {
     return computed(() => {
         if (props.size) {
             return props.size;
@@ -16,7 +16,7 @@ export function getSize(props, { only = ['sm', 'md', 'lg'] }) {
             return 'lg';
         }
 
-        return 'md';
+        return DEFAULT;
     });
 }
 

--- a/packages/admin-vue3/src/ui/props/variant.js
+++ b/packages/admin-vue3/src/ui/props/variant.js
@@ -1,6 +1,6 @@
 import { computed } from 'vue';
 
-export function getVariant(props) {
+export function getVariant(props, { DEFAULT = 'blue' }) {
     return computed(() => {
         if (props.variant) {
             return props.variant;
@@ -22,7 +22,7 @@ export function getVariant(props) {
             return 'red';
         }
 
-        return 'blue';
+        return DEFAULT;
     });
 }
 


### PR DESCRIPTION
I started working on the ui-cards, the following image shows variants of the card:

<img width="1439" alt="Bildschirmfoto 2021-06-24 um 17 09 23" src="https://user-images.githubusercontent.com/69738385/123287428-03359100-d50f-11eb-838d-bc70c4f9a2ca.png">

```vue
<ui-card class="w-full">Hello</ui-card>
<ui-card gray class="w-2/3">Hello</ui-card>
<ui-card gray sm class="w-1/3">Hello</ui-card>
<ui-card gray sm class="w-1/3 p-4">Hello</ui-card>
<ui-card as="div">Hello</ui-card>
<ui-card class="bg-blue text-white">Hello</ui-card>
```

A card also consists of a header slot, a standard content slot and a footer slot.

If there are any additional features you can think of please tell me.