### PR TITLE
update general layout of backend

### DIFF
--- a/packages/admin-vue3/src/layouts/default/DefaultLayout.vue
+++ b/packages/admin-vue3/src/layouts/default/DefaultLayout.vue
@@ -1,59 +1,22 @@
 <template>
-    <div class="flex w-screen">
-        <aside
-            class="
-                z-10
-                w-64
-                h-screen
-                p-4
-                overflow-y-scroll
-                text-white
-                bg-blue-900
-            "
-        >
-            <slot name="sidebar-header">
-                <DefaultLayoutHeader />
-            </slot>
-            <nav>
-                <slot name="sidebar" :sidebar="sidebar" />
-            </nav>
-        </aside>
-        <aside
-            class="w-64 h-screen p-4 bg-white border-r border-gray-300 shadow"
-            v-if="sidebar.isOpen"
-        >
+    <div class="flex w-screen h-screen max-h-screen">
+        <div id="sidebars" class="z-10 flex h-screen shadow">
+            <slot name="sidebar-primary" :sidebar="sidebar" />
             <slot name="sidebar-secondary" />
-        </aside>
-        <div class="flex flex-col flex-1 h-screen overflow-y-scroll">
-            <header class="sticky top-0 z-20 w-full bg-white">
-                <nav
-                    class="
-                        flex
-                        items-center
-                        justify-between
-                        h-12
-                        px-6
-                        border-b border-gray-300
-                    "
-                >
-                    <slot name="header" :sidebar="sidebar" />
-                </nav>
-                <nav
-                    class="
-                        flex
-                        items-center
-                        justify-between
-                        px-6
-                        text-xs
-                        border-b border-gray-300
-                        text-gray
-                    "
-                >
-                    <slot name="header-secondary" :sidebar="sidebar" />
-                </nav>
-            </header>
+        </div>
+        <div
+            class="relative flex flex-col flex-1 h-screen overflow-y-scroll bg-gray-50"
+        >
             <main class="relative flex-1 overflow-y-scroll">
-                <slot :sidebar="sidebar" />
+                <DefaultLayoutTopbar>
+                    <template v-slot:topbar-left>
+                        <slot name="topbar-left" />
+                    </template>
+                    <template v-slot:topbar-right>
+                        <slot name="topbar-right" />
+                    </template>
+                </DefaultLayoutTopbar>
+                <slot />
             </main>
         </div>
     </div>
@@ -63,10 +26,11 @@
 import { defineComponent, reactive } from 'vue';
 import TransitionSlide from '../../transitions/TransitionSlide.vue';
 import DefaultLayoutHeader from './DefaultLayoutHeader.vue';
+import DefaultLayoutTopbar from './DefaultLayoutTopbar.vue';
 import { TSidebar } from '../../..';
 
 export default defineComponent({
-    components: { TransitionSlide, DefaultLayoutHeader },
+    components: { TransitionSlide, DefaultLayoutHeader, DefaultLayoutTopbar },
     name: 'Layout',
     setup() {
         const sidebar = reactive<TSidebar>({

--- a/packages/admin-vue3/src/layouts/default/DefaultLayoutTopbar.vue
+++ b/packages/admin-vue3/src/layouts/default/DefaultLayoutTopbar.vue
@@ -1,0 +1,27 @@
+<template>
+    <div
+        class="sticky top-0 z-10 h-20 transition-all border-b border-gray-400 bg-gray-50"
+    >
+        <div class="container flex items-center justify-between h-full px-10">
+            <div
+                class="flex items-baseline space-x-4 font-medium text-gray-800"
+            >
+                <slot name="topbar-left" />
+            </div>
+            <div class="flex space-x-2">
+                <slot name="topbar-right" />
+            </div>
+        </div>
+        <div
+            class="container flex items-center justify-end space-x-4 text-sm text-gray-800"
+        >
+            <slot name="topbar-secondary" />
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const expanded = ref(false);
+</script>

--- a/packages/admin-vue3/src/layouts/guest/GuestLayout.vue
+++ b/packages/admin-vue3/src/layouts/guest/GuestLayout.vue
@@ -2,30 +2,14 @@
     <div class="flex w-screen h-screen">
         <div class="grid w-full h-full grid-cols-12">
             <div
-                class="
-                    flex flex-col
-                    items-center
-                    justify-center
-                    col-span-12
-                    gap-16
-                    bg-white
-                    md:col-span-6
-                "
+                class="flex flex-col items-center justify-center col-span-12 gap-16 bg-white md:col-span-6"
             >
-                <div class="w-full lg:w-1/2 px-12 lg:px-0">
+                <div class="w-full px-12 lg:w-1/2 lg:px-0">
                     <slot />
                 </div>
             </div>
             <div
-                class="
-                    flex
-                    items-center
-                    justify-center
-                    col-span-12
-                    text-white
-                    bg-blue-900
-                    md:col-span-6
-                "
+                class="flex items-center justify-center col-span-12 text-white bg-gray-300 md:col-span-6"
             >
                 <Logo />
             </div>

--- a/packages/admin-vue3/src/pages/ForgotPassword.vue
+++ b/packages/admin-vue3/src/pages/ForgotPassword.vue
@@ -1,7 +1,7 @@
 <template>
     <GuestLayout>
         <div class="mb-3 text-sm text-gray-600">{{ lang.message }}</div>
-        <div v-if="status" class="mb-4 font-medium text-sm text-green-600">
+        <div v-if="status" class="mb-4 text-sm font-medium text-green-600">
             {{ status }}
         </div>
         <form @submit.prevent="form.submit">
@@ -34,7 +34,7 @@ import { useForm } from '@macramejs/macrame-vue3';
 
 import GuestLayout from '../layouts/guest/GuestLayout.vue';
 import Input from '../layouts/guest/GuestLayoutInput.vue';
-import Checkbox from '../ui/Checkbox.vue';
+import Checkbox from '../ui/CheckboxSwitch.vue';
 import Button from '../ui/Button.vue';
 
 interface Lang {

--- a/packages/admin-vue3/src/pages/Login.vue
+++ b/packages/admin-vue3/src/pages/Login.vue
@@ -49,7 +49,7 @@ import { useForm } from '@macramejs/macrame-vue3';
 
 import GuestLayout from '../layouts/guest/GuestLayout.vue';
 import Input from '../layouts/guest/GuestLayoutInput.vue';
-import Checkbox from '../ui/Checkbox.vue';
+import Checkbox from '../ui/CheckboxSwitch.vue';
 import Button from '../ui/Button.vue';
 
 interface Lang {

--- a/packages/admin-vue3/src/pages/ResetPassword.vue
+++ b/packages/admin-vue3/src/pages/ResetPassword.vue
@@ -55,7 +55,7 @@ import { useForm } from '@macramejs/macrame-vue3';
 
 import GuestLayout from '../layouts/guest/GuestLayout.vue';
 import Input from '../layouts/guest/GuestLayoutInput.vue';
-import Checkbox from '../ui/Checkbox.vue';
+import Checkbox from '../ui/CheckboxSwitch.vue';
 import Button from '../ui/Button.vue';
 
 interface Lang {

--- a/packages/admin-vue3/src/ui/props/variant.js
+++ b/packages/admin-vue3/src/ui/props/variant.js
@@ -1,11 +1,26 @@
 import { computed } from 'vue';
 
-export function getVariant(props, { DEFAULT = 'blue' }) {
+export function getVariant(props, { DEFAULT = 'primary' }) {
     return computed(() => {
         if (props.variant) {
             return props.variant;
         }
 
+        if (props.primary) {
+            return 'primary';
+        }
+        if (props.secondary) {
+            return 'secondary';
+        }
+        if (props.small) {
+            return 'small';
+        }
+        if (props.text) {
+            return 'text';
+        }
+        if (props.round) {
+            return 'round';
+        }
         if (props.blue) {
             return 'blue';
         }
@@ -15,11 +30,44 @@ export function getVariant(props, { DEFAULT = 'blue' }) {
         if (props.green) {
             return 'green';
         }
+        if (props.success) {
+            return 'success';
+        }
         if (props.yellow) {
             return 'yellow';
         }
+        if (props.warning) {
+            return 'warning';
+        }
         if (props.red) {
             return 'red';
+        }
+        if (props.danger) {
+            return 'danger';
+        }
+        if (props.purple) {
+            return 'purple';
+        }
+        if (props.orange) {
+            return 'orange';
+        }
+        if (props.darkorange) {
+            return 'darkorange';
+        }
+        if (props.lightorange) {
+            return 'lightorange';
+        }
+        if (props.grasgreen) {
+            return 'grasgreen';
+        }
+        if (props.turkise) {
+            return 'turkise';
+        }
+        if (props.lightblue) {
+            return 'lightblue';
+        }
+        if (props.pink) {
+            return 'pink';
         }
 
         return DEFAULT;
@@ -35,6 +83,26 @@ export const variants = {
         type: Boolean,
         default: false,
     },
+    primary: {
+        type: Boolean,
+        default: false,
+    },
+    secondary: {
+        type: Boolean,
+        default: false,
+    },
+    small: {
+        type: Boolean,
+        default: false,
+    },
+    text: {
+        type: Boolean,
+        default: false,
+    },
+    round: {
+        type: Boolean,
+        default: false,
+    },
     gray: {
         type: Boolean,
         default: false,
@@ -43,11 +111,55 @@ export const variants = {
         type: Boolean,
         default: false,
     },
+    success: {
+        type: Boolean,
+        default: false,
+    },
     yellow: {
         type: Boolean,
         default: false,
     },
+    warning: {
+        type: Boolean,
+        default: false,
+    },
     red: {
+        type: Boolean,
+        default: false,
+    },
+    danger: {
+        type: Boolean,
+        default: false,
+    },
+    orange: {
+        type: Boolean,
+        default: false,
+    },
+    purple: {
+        type: Boolean,
+        default: false,
+    },
+    darkorange: {
+        type: Boolean,
+        default: false,
+    },
+    lightorange: {
+        type: Boolean,
+        default: false,
+    },
+    grasgreen: {
+        type: Boolean,
+        default: false,
+    },
+    turkise: {
+        type: Boolean,
+        default: false,
+    },
+    lightblue: {
+        type: Boolean,
+        default: false,
+    },
+    pink: {
         type: Boolean,
         default: false,
     },

--- a/packages/admin-vue3/tailwind.config.js
+++ b/packages/admin-vue3/tailwind.config.js
@@ -1,4 +1,4 @@
 module.exports = {
     presets: [require('@macramejs/admin-config')],
-    purge: [__dirname + '/ui/**/*.vue'],
+    content: [__dirname + '/ui/**/*.vue'],
 };


### PR DESCRIPTION
This PR updates the layout of the general admin pages (login/pw reset). The backend DefaultLayout.vue now consists of two sidebars (primary and secondary), a topbar which consists of a left and a right section) and the main slot for the content. This PR requires some new UI components to be merged and should therefore only be merged if the following componnets are in the core:
- CheckboxSwitch