### PR TITLE
add chip  ui component

### DIFF
--- a/packages/admin-vue3/src/ui/Chip.vue
+++ b/packages/admin-vue3/src/ui/Chip.vue
@@ -1,0 +1,51 @@
+<template>
+    <button
+        @click="update(!modelValue)"
+        class="h-[30px] px-3 py-2 transition-colors focus:outline-none duration-200 rounded-full leading-none text-sm"
+        :class="{
+            'bg-gray-200 hover:bg-gray-400 text-gray-900 focus:bg-gray-300 active:bg-orange-100':
+                !modelValue && !disabled,
+            'bg-orange-100 text-orange-700': modelValue && !disabled,
+            'bg-gray-100 text-gray-500 cursor-not-allowed': disabled,
+        }"
+        :disabled="disabled"
+    >
+        {{ label }}
+    </button>
+</template>
+
+<script lang="ts">
+import { ref } from 'vue';
+import { Switch, SwitchGroup, SwitchLabel } from '@headlessui/vue';
+import { getSize, sizes } from './props/size';
+import { getVariant, variants } from './props/variant';
+
+export default {
+    components: { Switch, SwitchGroup, SwitchLabel },
+    props: {
+        label: {
+            type: String,
+            default: null,
+        },
+        disabled: {
+            type: Boolean,
+            default: false,
+        },
+        modelValue: {
+            type: Boolean,
+            default: false,
+        },
+    },
+
+    setup({ disabled }, { emit }) {
+        const update = value => {
+            if (disabled) {
+                return;
+            }
+            emit('update:modelValue', value);
+        };
+
+        return { update };
+    },
+};
+</script>


### PR DESCRIPTION
This PR adds a chip ui component, which can be used for tags.

<img width="503" alt="Bildschirmfoto 2022-01-31 um 14 01 58" src="https://user-images.githubusercontent.com/69738385/151798126-d1130ad5-83a5-4917-8863-042dc4572356.png">
