### PR TITLE
updated badge component styling

### DIFF
--- a/packages/admin-vue3/src/ui/Badge.vue
+++ b/packages/admin-vue3/src/ui/Badge.vue
@@ -1,21 +1,24 @@
 <template>
     <component
         :is="tag"
-        class="inline-flex items-center justify-center px-2 text-sm rounded-xs"
+        class="inline-flex items-center justify-center px-3 py-2 text-xs font-medium rounded-full"
         :class="{
             'bg-gradient-to-r from-red-500 to-orange-500 text-white ':
                 variant_ == 'primary',
-            'bg-gray-800 text-white': variant_ == 'gray',
-            'bg-darkorange text-white':
+            'bg-gray-800 text-gray': variant_ == 'gray',
+            'bg-darkorange text-darkorange bg-opacity-30':
                 variant_ == 'darkorange' || variant_ == 'orange',
-            'bg-lightorange text-white': variant_ == 'lightorange',
-            'bg-grasgreen text-white':
+            'bg-lightorange text-lightorange bg-opacity-30':
+                variant_ == 'lightorange',
+            'bg-grasgreen text-grasgreen bg-opacity-30':
                 variant_ == 'grasgreen' || variant_ == 'green',
-            'bg-turkise text-white': variant_ == 'turkise',
-            'bg-lightblue text-gray-800': variant_ == 'lightblue',
-            'bg-blue text-white': variant_ == 'blue',
-            'bg-purple text-white': variant_ == 'purple',
-            'bg-pink text-gray-800': variant_ == 'pink',
+            'bg-turkise text-turkise bg-opacity-30': variant_ == 'turkise',
+            'bg-lightblue text-lightblue bg-opacity-30':
+                variant_ == 'lightblue',
+            'bg-blue text-blue bg-opacity-30': variant_ == 'blue',
+            'bg-red-signal text-red-signal bg-opacity-30': variant_ == 'red',
+            'bg-purple text-purple bg-opacity-30': variant_ == 'purple',
+            'bg-pink text-pink bg-opacity-30': variant_ == 'pink',
         }"
     >
         <slot />


### PR DESCRIPTION
<img width="669" alt="Bildschirmfoto 2022-02-01 um 12 57 51" src="https://user-images.githubusercontent.com/69738385/151964597-55aa4501-7365-45a2-81ef-0d5b5545f70a.png">

```vue
<Badge primary class="m-2">Foo</Badge>
<Badge gray class="m-2">Foo</Badge>
<Badge green class="m-2">Foo</Badge>
<Badge turkise class="m-2">Foo</Badge>
<Badge purple class="m-2">Foo</Badge>
<Badge pink class="m-2">Foo</Badge>
<Badge orange class="m-2">Foo</Badge>
<Badge lightorange class="m-2">Foo</Badge>
<Badge red class="m-2">Foo</Badge>
<Badge blue class="m-2">Foo</Badge>
<Badge lightblue class="m-2">Foo</Badge>
```