### PR TITLE
fix input to work on every background

### DIFF
--- a/packages/admin-vue3/src/ui/Input.vue
+++ b/packages/admin-vue3/src/ui/Input.vue
@@ -113,6 +113,9 @@ input:focus + div > .input-section-2 {
     border-bottom-color: #fead5e;
     border-top-color: #fead5e;
 }
+input:focus + div > .input-section-2 > label {
+    color: #ff744e;
+}
 input:focus + div > .input-section-3 {
     border-color: #fead5e;
 }

--- a/packages/admin-vue3/src/ui/Input.vue
+++ b/packages/admin-vue3/src/ui/Input.vue
@@ -1,32 +1,61 @@
 <template>
     <div class="relative">
-        <span
-            v-if="label"
-            class="absolute inline-block transition-all duration-200 -translate-y-1/2 pointer-events-none bg-"
-            :class="{
-                'top-1/2 left-[18px] text-gray-500':
-                    $attrs.modelValue?.length == 0 || !$attrs.modelValue,
-                'top-px left-[16px] text-indigo-900 bg-white p-1 text-xs':
-                    $attrs.modelValue?.length > 0,
-            }"
-        >
-            {{ label }}
-        </span>
         <BaseInput
             v-bind="$attrs"
+            :id="id"
             :disabled="disabled"
-            class="px-[18px] border z-10 transition-colors duration-200 focus:outline-none rounded text-indigo-900 py-2.5"
+            @focus="focused = true"
+            @blur="focused = false"
+            class="px-[18px] z-10 w-full transition-colors duration-200 bg-transparent focus:outline-none focus:input-focused text-indigo-900 py-2.5"
             :class="{
-                'border-gray-200 cursor-not-allowed bg-gray-50': disabled,
-                'border-gray-500 bg-white focus:border-orange-700':
-                    errors.length == 0 && !disabled,
-                'border-red-signal bg-gray-50': errors.length > 0 && !disabled,
+                'cursor-not-allowed': disabled,
+                'has-errors': errors.length > 0 && !disabled,
             }"
         />
+        <div
+            class="absolute top-0 left-0 right-0 flex w-full h-full max-w-full pointer-events-none"
+        >
+            <div
+                class="border-l input-section-1 border-t border-b border-gray-500 w-[16px] h-full rounded-l-[8px]"
+            ></div>
+            <div
+                class="relative h-full px-1 border-t border-b border-gray-500 input-width input-section-2"
+                :class="{
+                    '!border-t-transparent':
+                        $attrs.modelValue?.length > 0 || focused,
+                    'border-t-gray-500':
+                        $attrs.modelValue?.length == 0 || !$attrs.modelValue,
+                }"
+            >
+                <label
+                    class="relative inline-block text-sm transition duration-200 origin-left whitespace-nowrap will-change-auto h-fit top-1/2"
+                    ref="inputLabel"
+                    :class="{
+                        'text-ellipsis !-translate-y-[35px] !scale-100 text-indigo-900':
+                            $attrs.modelValue?.length > 0 || focused,
+                        'max-w-full -translate-y-[13px] scale-[1.34] text-gray-500':
+                            $attrs.modelValue?.length == 0 ||
+                            !$attrs.modelValue,
+                        '!text-red-signal':
+                            ($attrs.modelValue?.length > 0 &&
+                                errors.length > 0 &&
+                                !disabled) ||
+                            (focused && errors.length > 0 && !disabled),
+                    }"
+                    :for="id"
+                >
+                    {{ label }}
+                </label>
+            </div>
+            <div
+                class="border-r border-t input-section-3 border-b focus:border-orange border-gray-500 flex-grow rounded-r-[8px] h-full"
+            ></div>
+        </div>
     </div>
 </template>
 
 <script lang="ts" setup>
+import { ref, watch, computed, onMounted } from 'vue';
 import { Input as BaseInput } from '@macramejs/macrame-vue3';
 
 defineProps({
@@ -47,6 +76,26 @@ defineProps({
         default: [],
     },
 });
+
+const focused = ref(false);
+
+const id = `mcr-input-${Math.random() * 1000000}`;
+
+const inputLabel = ref();
+
+const labelWidth = computed(() => {
+    return inputLabel.value?.clientWidth * 0.95;
+});
+
+onMounted(() => {
+    inputLabel.value = document.querySelector(
+        `label[for="${id}"]`
+    ).parentElement;
+});
+
+// watch(inputLabel, () => {
+//     console.log(inputLabel.value.style.width);
+// });
 </script>
 
 <script lang="ts">
@@ -55,3 +104,34 @@ export default {
     customOptions: {},
 };
 </script>
+
+<style scoped>
+input:focus + div > .input-section-1 {
+    border-color: #fead5e;
+}
+input:focus + div > .input-section-2 {
+    border-bottom-color: #fead5e;
+    border-top-color: #fead5e;
+}
+input:focus + div > .input-section-3 {
+    border-color: #fead5e;
+}
+
+.input-width {
+    flex: 0 0 auto;
+    max-width: calc(100% - 12px * 2);
+}
+.input-width-focused {
+    max-width: calc(100% * 0.75);
+}
+input.has-errors + div > .input-section-1 {
+    border-color: #f74b6d;
+}
+input.has-errors + div > .input-section-2 {
+    border-bottom-color: #f74b6d;
+    border-top-color: #f74b6d;
+}
+input.has-errors + div > .input-section-3 {
+    border-color: #f74b6d;
+}
+</style>


### PR DESCRIPTION
This PR fixes the styling of the input to work on every background color. Previously the input only worked on white backgrounds due to the label having a white background. The changes are inspired by the google material input, which works in a very similar manner. Input behavior remains unchanged.