### PR TITLE
placed hint and errors for form field on right side

### DIFF
--- a/packages/admin-vue3/src/ui/FormField.vue
+++ b/packages/admin-vue3/src/ui/FormField.vue
@@ -8,11 +8,11 @@
         <slot />
         <div
             v-if="hint && !errors"
-            class="ml-[18px] mt-1 text-xs text-gray-500"
+            class="mt-1 text-xs text-right text-gray-500"
         >
             {{ hint }}
         </div>
-        <div v-if="errors">
+        <div class="text-right" v-if="errors">
             <span
                 v-for="(error, key) in errorList"
                 :key="key"
@@ -39,7 +39,7 @@ const props = defineProps({
     hint: {
         type: String,
     },
-    noLable: {
+    noLabel: {
         type: Boolean,
         default: false,
     },


### PR DESCRIPTION
This PR changes the placement of hints and errors on formfields, they are now on the right bottom side instead of the left bottom