### PR TITLE
added active state to TabPanel

### DIFF
--- a/packages/admin-vue3/src/ui/TabPanel.vue
+++ b/packages/admin-vue3/src/ui/TabPanel.vue
@@ -1,14 +1,56 @@
 <template>
     <TabPanel class="relative flex justify-between w-full">
-        <div class="flex-1 px-10">
+        <div
+            class="flex-1 px-10 overflow-y-auto"
+            :style="`height: calc(100vh - ${sidebarTopPosition}px); top: ${sidebarTopPosition}px;`"
+        >
             <slot />
         </div>
         <template v-if="hasSidebar">
             <div
-                class="w-[233px] sticky bg-white shadow"
+                class="sticky flex flex-col transition-all duration-300 bg-white shadow"
                 :style="`height: calc(100vh - ${sidebarTopPosition}px); top: ${sidebarTopPosition}px;`"
+                :class="{
+                    'w-[233px]': sidebarActive,
+                    'w-[60px]': !sidebarActive,
+                }"
             >
-                <slot name="sidebar" />
+                <div class="w-full overflow-y-auto h-4/5">
+                    <slot v-if="sidebarActive" name="sidebar" />
+                    <div class="w-full p-4 mt-4" v-if="!sidebarActive">
+                        <div class="flex items-center w-full gap-4 rotate-90">
+                            <slot name="sidebarTitle" />
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="flex items-center w-full px-4 mt-auto border-t border-gray-400 h-1/5"
+                >
+                    <button
+                        @click="toggleSidebar()"
+                        class="p-1 bg-gray-100 rounded"
+                    >
+                        <svg
+                            width="24"
+                            height="24"
+                            stroke-width="1.5"
+                            fill="none"
+                            class="transition-transform duration-300 scale-[0.8]"
+                            :class="{
+                                'rotate-180': sidebarActive,
+                                'rotate-0': !sidebarActive,
+                            }"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="M18.5 12H6m0 0 6-6m-6 6 6 6"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                            />
+                        </svg>
+                    </button>
+                </div>
             </div>
         </template>
     </TabPanel>
@@ -16,6 +58,7 @@
 
 <script lang="ts" setup>
 import { TabPanel } from '@headlessui/vue';
+import { ref } from 'vue';
 
 defineProps({
     hasSidebar: {
@@ -27,4 +70,14 @@ defineProps({
         default: '110',
     },
 });
+
+const sidebarActive = ref(true);
+
+const toggleSidebar = () => {
+    if (sidebarActive.value) {
+        sidebarActive.value = false;
+        return;
+    }
+    sidebarActive.value = true;
+};
 </script>


### PR DESCRIPTION
This PR adds an active state to the tabpanel sidebar that is initially always true. The TabPanel can hold drawers for pages pages for example but maybe people would like to have more space for editing the existing components. They can do this by pressing a button at the bottom of the side bar that makes the sidebar smaller.

<img width="1380" alt="Bildschirmfoto 2022-05-13 um 09 46 38" src="https://user-images.githubusercontent.com/69738385/168236474-df3c7577-b1d5-4681-abdf-a12395928609.png">


<img width="1390" alt="Bildschirmfoto 2022-05-13 um 09 46 46" src="https://user-images.githubusercontent.com/69738385/168236370-87a89806-1984-4e4e-9338-9bcdbaffe173.png">

