### PR TITLE
Icons and BaseSection

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+    "trailingComma": "es5",
+    "semi": true,
+    "singleQuote": true,
+    "useTabs": false,
+    "tabWidth": 4,
+    "printWidth": 80,
+    "arrowParens": "avoid"
+}

--- a/packages/admin-vue3/src/icons/IconDraggable.vue
+++ b/packages/admin-vue3/src/icons/IconDraggable.vue
@@ -1,0 +1,11 @@
+<template>
+    <svg
+        viewBox="0 0 18 9"
+        xmlns="http://www.w3.org/2000/svg"
+        xml:space="preserve"
+    >
+        <path
+            d="M18 7.597a1 1 0 0 0-1-1H1a1 1 0 0 0 0 2h16a1 1 0 0 0 1-1ZM18 1a1 1 0 0 0-1-1H1a1 1 0 0 0 0 2h16a1 1 0 0 0 1-1Z"
+        />
+    </svg>
+</template>

--- a/packages/admin-vue3/src/icons/IconEditPencil.vue
+++ b/packages/admin-vue3/src/icons/IconEditPencil.vue
@@ -1,0 +1,17 @@
+<template>
+    <svg
+        width="12"
+        height="12"
+        stroke-width="1.5"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M13.0207 5.82839L15.8491 2.99996L20.7988 7.94971L17.9704 10.7781M13.0207 5.82839L3.41405 15.435C3.22652 15.6225 3.12116 15.8769 3.12116 16.1421V20.6776H7.65669C7.92191 20.6776 8.17626 20.5723 8.3638 20.3847L17.9704 10.7781M13.0207 5.82839L17.9704 10.7781"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+    </svg>
+</template>

--- a/packages/admin-vue3/src/icons/IconMoreHorizontal.vue
+++ b/packages/admin-vue3/src/icons/IconMoreHorizontal.vue
@@ -1,0 +1,16 @@
+<template>
+    <svg
+        width="24"
+        height="24"
+        stroke-width="1.5"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M19 11v9.4a.6.6 0 0 1-.6.6H5.6a.6.6 0 0 1-.6-.6V11M10 17v-6M14 17v-6M21 7h-5M3 7h5m0 0V3.6a.6.6 0 0 1 .6-.6h6.8a.6.6 0 0 1 .6.6V7M8 7h8"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+    </svg>
+</template>

--- a/packages/admin-vue3/src/icons/IconTrash.vue
+++ b/packages/admin-vue3/src/icons/IconTrash.vue
@@ -1,0 +1,17 @@
+<template>
+    <svg
+        width="24"
+        height="24"
+        class="origin-left scale-75"
+        stroke-width="1.5"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M19 11v9.4a.6.6 0 0 1-.6.6H5.6a.6.6 0 0 1-.6-.6V11M10 17v-6M14 17v-6M21 7h-5M3 7h5m0 0V3.6a.6.6 0 0 1 .6-.6h6.8a.6.6 0 0 1 .6.6V7M8 7h8"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+    </svg>
+</template>

--- a/packages/admin-vue3/src/icons/index.ts
+++ b/packages/admin-vue3/src/icons/index.ts
@@ -1,0 +1,4 @@
+export { default as IconDraggable } from './IconDraggable.vue';
+export { default as IconTrash } from './IconTrash.vue';
+export { default as IconMoreHorizontal } from './IconMoreHorizontal.vue';
+export { default as IconEditPencil } from './IconEditPencil.vue';

--- a/packages/admin-vue3/src/index.ts
+++ b/packages/admin-vue3/src/index.ts
@@ -74,32 +74,25 @@ import DefaultLayout from './layouts/default/DefaultLayout.vue';
 import DefaultLayoutHeader from './layouts/default/DefaultLayoutHeader.vue';
 import DefaultLayoutBurger from './layouts/default/DefaultLayoutBurger.vue';
 
-export {
-    DefaultLayout,
-    DefaultLayoutHeader,
-    DefaultLayoutBurger
-};
+export { DefaultLayout, DefaultLayoutHeader, DefaultLayoutBurger };
 
 import GuestLayout from './layouts/guest/GuestLayout.vue';
 import GuestLayoutInput from './layouts/guest/GuestLayoutInput.vue';
 
-export {
-    GuestLayout,
-    GuestLayoutInput
-};
+export { GuestLayout, GuestLayoutInput };
 
 import LoginPage from './pages/Auth/Login.vue';
 import ForgotPasswordPage from './pages/Auth/ForgotPassword.vue';
 import ResetPasswordPage from './pages/Auth/ResetPassword.vue';
 
 const AuthPages = {
-    "Auth/Login": LoginPage,
-    "Auth/ForgotPassword": ForgotPasswordPage,
-    "Auth/ResetPassword": ResetPasswordPage,
-}
+    'Auth/Login': LoginPage,
+    'Auth/ForgotPassword': ForgotPasswordPage,
+    'Auth/ResetPassword': ResetPasswordPage,
+};
 
-const Pages = { 
-    auth: AuthPages 
+const Pages = {
+    auth: AuthPages,
 };
 
 export { Pages, AuthPages };
@@ -132,7 +125,7 @@ export {
     CheckboxSwitch,
     DatePicker,
     DateRange,
-    Index, 
+    Index,
     Input,
     // Slider,
     // Nested,
@@ -148,6 +141,9 @@ export {
     RadioGroup,
     Pagination,
     Textarea,
-    Table, Tr, Th, Td,
-    Wysiwyg
+    Table,
+    Tr,
+    Th,
+    Td,
+    Wysiwyg,
 };

--- a/packages/admin-vue3/src/index.ts
+++ b/packages/admin-vue3/src/index.ts
@@ -99,10 +99,7 @@ const Pages = {
 export { Pages, AuthPages };
 
 // Icons
-import IconDraggable from './icons/IconDraggable.vue';
-import IconTrash from './icons/IconTrash.vue';
-import IconMoreHorizontal from './icons/IconMoreHorizontal.vue';
-export { IconDraggable, IconTrash, IconMoreHorizontal };
+export * from './icons';
 
 // Components
 export {

--- a/packages/admin-vue3/src/index.ts
+++ b/packages/admin-vue3/src/index.ts
@@ -32,6 +32,7 @@ import Tree from './ui/Tree.vue';
 import TreeItem from './ui/TreeItem.vue';
 import Search from './ui/Search.vue';
 import Select from './ui/Select.vue';
+import Section from './ui/Section.vue';
 import Sections from './ui/Sections.vue';
 import Sidebar from './ui/Sidebar.vue';
 import SidebarLink from './ui/SidebarLink.vue';
@@ -101,6 +102,7 @@ export { Pages, AuthPages };
 import IconDraggable from './icons/IconDraggable.vue';
 import IconTrash from './icons/IconTrash.vue';
 export { IconDraggable, IconTrash };
+
 // Components
 export {
     Card,
@@ -120,6 +122,7 @@ export {
     TabPanel,
     TabGroup,
     TabList,
+    Section,
     Sections,
     Form,
     FormField,

--- a/packages/admin-vue3/src/index.ts
+++ b/packages/admin-vue3/src/index.ts
@@ -101,7 +101,8 @@ export { Pages, AuthPages };
 // Icons
 import IconDraggable from './icons/IconDraggable.vue';
 import IconTrash from './icons/IconTrash.vue';
-export { IconDraggable, IconTrash };
+import IconMoreHorizontal from './icons/IconMoreHorizontal.vue';
+export { IconDraggable, IconTrash, IconMoreHorizontal };
 
 // Components
 export {

--- a/packages/admin-vue3/src/index.ts
+++ b/packages/admin-vue3/src/index.ts
@@ -97,6 +97,10 @@ const Pages = {
 
 export { Pages, AuthPages };
 
+// Icons
+import IconDraggable from './icons/IconDraggable.vue';
+import IconTrash from './icons/IconTrash.vue';
+export { IconDraggable, IconTrash };
 // Components
 export {
     Card,

--- a/packages/admin-vue3/src/ui/Section.vue
+++ b/packages/admin-vue3/src/ui/Section.vue
@@ -25,8 +25,8 @@ import Card from './Card.vue';
 import ContextButton from './ContextButton.vue';
 import ContextMenu from './ContextMenu.vue';
 import ContextMenuItem from './ContextMenuItem.vue';
-import IconDraggable from './IconDraggable.vue';
-import IconTrash from './IconTrash.vue';
+import IconDraggable from '../icons/IconDraggable.vue';
+import IconTrash from '../icons/IconTrash.vue';
 
 const emit = defineEmits(['destroy']);
 </script>

--- a/packages/admin-vue3/src/ui/Section.vue
+++ b/packages/admin-vue3/src/ui/Section.vue
@@ -1,0 +1,32 @@
+<template>
+    <Card class="p-4 px-8 cursor-move mb-4">
+        <div class="flex">
+            <IconDraggable class="w-2.5 h-2.5 fill-gray mt-2 mb-4 mr-auto" />
+            <ContextMenu>
+                <template #button>
+                    <ContextButton />
+                </template>
+                <ContextMenuItem
+                    class="hover:bg-red-signal text-red-signal"
+                    @click="emit('destroy')"
+                >
+                    <template #icon>
+                        <IconTrash class="origin-left scale-75" />
+                    </template>
+                    <span>Delete</span>
+                </ContextMenuItem>
+            </ContextMenu>
+        </div>
+        <slot />
+    </Card>
+</template>
+<script setup lang="ts">
+import Card from './Card.vue';
+import ContextButton from './ContextButton.vue';
+import ContextMenu from './ContextMenu.vue';
+import ContextMenuItem from './ContextMenuItem.vue';
+import IconDraggable from './IconDraggable.vue';
+import IconTrash from './IconTrash.vue';
+
+const emit = defineEmits(['destroy']);
+</script>


### PR DESCRIPTION
This PR adds as BaseSection for the page builder sections, which includes the "removing" mechanism.

Currently it's rendered as a Card by default, but that may be subject to change.

- add prettierrc
- formatting
- add icons
- add (base) section
