### PR TITLE
Store sidebar lock status

### DIFF
--- a/packages/admin-vue3/src/icons/IconLocked.vue
+++ b/packages/admin-vue3/src/icons/IconLocked.vue
@@ -1,0 +1,17 @@
+<template>
+    <svg
+        width="24"
+        height="24"
+        stroke-width="1.5"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M16 12H17.4C17.7314 12 18 12.2686 18 12.6V19.4C18 19.7314 17.7314 20 17.4 20H6.6C6.26863 20 6 19.7314 6 19.4V12.6C6 12.2686 6.26863 12 6.6 12H8M16 12V8C16 6.66667 15.2 4 12 4C8.8 4 8 6.66667 8 8V12M16 12H8"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+    </svg>
+</template>

--- a/packages/admin-vue3/src/icons/IconUnlocked.vue
+++ b/packages/admin-vue3/src/icons/IconUnlocked.vue
@@ -1,0 +1,41 @@
+<template>
+    <svg
+        width="24"
+        height="24"
+        stroke-width="1.5"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M11.5 12H6.6C6.26863 12 6 12.2686 6 12.6V19.4C6 19.7314 6.26863 20 6.6 20H17.4C17.7314 20 18 19.7314 18 19.4V18.5"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+        <path
+            d="M16 12V8C16 6.66667 15.2 4 12 4C11.2532 4 10.6371 4.14525 10.1313 4.38491"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+        <path
+            d="M16 12H17.4C17.7314 12 18 12.2686 18 12.6V13"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+        <path
+            d="M8 8V8.5V12"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+        <path
+            d="M3 3L21 21"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+    </svg>
+</template>

--- a/packages/admin-vue3/src/icons/index.ts
+++ b/packages/admin-vue3/src/icons/index.ts
@@ -7,3 +7,5 @@ export { default as IconAddImage } from './IconAddImage.vue';
 export { default as IconBookStack } from './IconBookStack.vue';
 export { default as IconMediaImageFolder } from './IconMediaImageFolder.vue';
 export { default as IconPlus } from './IconPlus.vue';
+export { default as IconLocked } from './IconLocked.vue';
+export { default as IconUnlocked } from './IconUnlocked.vue';

--- a/packages/admin-vue3/src/ui/SidebarPrimary/components/LockSidebar.vue
+++ b/packages/admin-vue3/src/ui/SidebarPrimary/components/LockSidebar.vue
@@ -1,32 +1,30 @@
 <template>
     <div
-        class="flex items-center justify-center w-5 h-5 rounded-xs" @click="emit('update:modelValue', !modelValue)"
+        class="flex items-center justify-center w-5 h-5 rounded-xs"
+        @click="toggle"
         :class="{
             'text-white bg-gray-800': modelValue,
             'text-gray-800 bg-gray-100': !modelValue,
         }"
     >
-        <svg v-if="modelValue" class="w-3 h-3" width="24" height="24" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M16 12H17.4C17.7314 12 18 12.2686 18 12.6V19.4C18 19.7314 17.7314 20 17.4 20H6.6C6.26863 20 6 19.7314 6 19.4V12.6C6 12.2686 6.26863 12 6.6 12H8M16 12V8C16 6.66667 15.2 4 12 4C8.8 4 8 6.66667 8 8V12M16 12H8" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-        <svg v-if="!modelValue" class="w-3 h-3" width="24" height="24" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M11.5 12H6.6C6.26863 12 6 12.2686 6 12.6V19.4C6 19.7314 6.26863 20 6.6 20H17.4C17.7314 20 18 19.7314 18 19.4V18.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M16 12V8C16 6.66667 15.2 4 12 4C11.2532 4 10.6371 4.14525 10.1313 4.38491" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M16 12H17.4C17.7314 12 18 12.2686 18 12.6V13" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M8 8V8.5V12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M3 3L21 21" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
+        <IconLocked v-if="modelValue" class="w-3 h-3" />
+        <IconUnlocked v-if="!modelValue" class="w-3 h-3" />
     </div>
 </template>
 
 <script setup lang="ts">
-defineProps({
+import { IconLocked, IconUnlocked } from '../../../icons';
+const props = defineProps({
     modelValue: {
         type: Boolean,
-        required: true
-    }
-})
+        required: true,
+    },
+});
 
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue']);
 
+const toggle = () => {
+    emit('update:modelValue', !props.modelValue);
+    localStorage.setItem('sideBarLocked', !props.modelValue);
+};
 </script>


### PR DESCRIPTION
This PR stores the LockSidebar state in LocalStorage as well. This enables to pass a computed property to the `SidebarPrimary` component, which takes the local storage into account:

```vue
<SidebarPrimary :locked="locked">
   //...
</SidebarPrimary

//...

const locked = computed(() => {
    if (localStorage.hasOwnProperty('sideBarLocked')) {
        return JSON.parse(localStorage.getItem('sideBarLocked'));
    }
    return false;
});
```

- add lock icons
- store state in localStorage
