### PR TITLE
Fix TreeItem styling

### DIFF
--- a/packages/admin-vue3/src/ui/TreeItem.vue
+++ b/packages/admin-vue3/src/ui/TreeItem.vue
@@ -2,13 +2,19 @@
     <Disclosure v-slot="{ open }" defaultOpen>
         <div class="flex items-center justify-between w-full group">
             <div
-                class="flex justify-between flex-1 pl-3 pr-2 rounded hover:bg-gray-500 hover:bg-opacity-20 bg-opacity-10"
+                class="flex justify-between flex-1 pl-3 pr-2 rounded"
                 :class="{
-                    'bg-gray-500': isActive,
+                    'bg-gray-500': isActive && background,
+                    'border-gray border': outline,
+                    'hover:bg-gray-500 hover:bg-opacity-20 bg-opacity-10':
+                        background,
                 }"
             >
                 <div
-                    class="flex items-center pr-3 text-gray-100 cursor-move handle"
+                    class="flex items-center pr-3 cursor-move handle"
+                    :class="{
+                        'text-gray-100': background,
+                    }"
                 >
                     <svg
                         class="w-2.5 h-2.5 fill-gray"
@@ -22,15 +28,21 @@
                     </svg>
                 </div>
                 <div
-                    class="flex items-center justify-between flex-1 text-gray-100"
+                    class="flex items-center justify-between flex-1"
+                    :class="{
+                        'text-gray-100': background,
+                    }"
                 >
                     <slot />
                 </div>
             </div>
             <div class="flex items-center w-8">
                 <DisclosureButton
-                    class="p-1 text-gray-100 hover:bg-black rounded-xs"
-                    :class="{ 'rotate-180': !open }"
+                    class="p-1 hover:bg-black rounded-xs"
+                    :class="{
+                        'text-gray-100': background,
+                        'rotate-180': !open,
+                    }"
                     v-if="children?.items.length > 0"
                 >
                     <svg
@@ -69,6 +81,14 @@ const props = defineProps({
         required: true,
     },
     isActive: {
+        type: Boolean,
+        default: false,
+    },
+    background: {
+        type: Boolean,
+        default: false,
+    },
+    outline: {
         type: Boolean,
         default: false,
     },

--- a/packages/admin-vue3/src/ui/TreeItem.vue
+++ b/packages/admin-vue3/src/ui/TreeItem.vue
@@ -16,16 +16,12 @@
                         'text-gray-100': background,
                     }"
                 >
-                    <svg
-                        class="w-2.5 h-2.5 fill-gray"
-                        viewBox="0 0 18 9"
-                        xmlns="http://www.w3.org/2000/svg"
-                        xml:space="preserve"
-                    >
-                        <path
-                            d="M18 7.597a1 1 0 0 0-1-1H1a1 1 0 0 0 0 2h16a1 1 0 0 0 1-1ZM18 1a1 1 0 0 0-1-1H1a1 1 0 0 0 0 2h16a1 1 0 0 0 1-1Z"
-                        />
-                    </svg>
+                    <IconDraggable
+                        class="w-2.5 h-2.5"
+                        :class="{
+                            'fill-gray': background,
+                        }"
+                    />
                 </div>
                 <div
                     class="flex items-center justify-between flex-1"
@@ -45,22 +41,7 @@
                     }"
                     v-if="children?.items.length > 0"
                 >
-                    <svg
-                        width="24"
-                        height="24"
-                        stroke-width="1.5"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="w-3 h-3"
-                    >
-                        <path
-                            d="M6 9L12 15L18 9"
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                        />
-                    </svg>
+                    <IconCaret />
                 </DisclosureButton>
             </div>
         </div>
@@ -72,6 +53,7 @@
 
 <script lang="ts" setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
+import { IconDraggable, IconCaret } from '../icons/';
 
 const props = defineProps({
     item: {


### PR DESCRIPTION
This PR updates the TreeItem component with some styling options to make the changes made in #87 optional when using the Tree on another background than the dark sidebar. The TreeItem is now mostly "unstyled" by default but can be adjusted with and `outline` and a `background` prop.

Sidebar with `backgound`:
<img width="314" alt="screenshot 14" src="https://user-images.githubusercontent.com/36259611/169482833-21579332-388a-48a1-b5dd-2a19af5000c8.png">

Navigation Tree with `outline`:
<img width="623" alt="screenshot 13" src="https://user-images.githubusercontent.com/36259611/169482927-af2591e2-c296-4ccb-9c4c-61565d9ec8f0.png">


- add background and outline styling options
- replace svgs with icon components
