### PR TITLE
fix link is active

### DIFF
--- a/packages/admin-vue3/src/ui/SidebarLink.vue
+++ b/packages/admin-vue3/src/ui/SidebarLink.vue
@@ -54,13 +54,13 @@ const props = defineProps({
     },
     active: {
         type: Boolean,
-        default: false,
+        default: undefined,
     },
 });
 
 const isActive = computed(() => {
-    if (props.active) {
-        return true;
+    if (props.active !== undefined) {
+        return props.active;
     }
 
     if (


### PR DESCRIPTION
This PR fixes the option to set the active state to false.
This was already included but broke many other links so i had to revert it. Turns out - it's been only the missing `default = undefined` that solves the issues for all of us :) 

edit: 💯